### PR TITLE
Add: Documentation of test results on real world chargers

### DIFF
--- a/doc/charger_test_results.md
+++ b/doc/charger_test_results.md
@@ -1,9 +1,9 @@
 # Test results on different chargers
-Please add your test result above past test results of your tested charger model (if there are already tests on it). If your charger model is not already listed here, please add it as a new section below the other models and add your data.
+### Adding test results:
+Please add test result above past test results of your tested charger model (if there are already tests on it). If your charger model is not already listed here, please add it as a new section below the other models and add your data.
 Thank you for contributing to the list!
 
-(proposed) Formatting Style:
-
+### (proposed) Formatting Style:
 
 ## Manufacturer Modelname
 

--- a/doc/charger_test_results.md
+++ b/doc/charger_test_results.md
@@ -1,0 +1,27 @@
+# Test results on different chargers
+Please add your test result above past test results of your tested charger model (if there are already tests on it). If your charger model is not already listed here, please add it as a new section below the other models and add your data.
+Thank you for contributing to the list!
+
+(proposed) Formatting Style:
+
+
+## Manufacturer Modelname
+
+Test Site: e.g. Going Electric Link (not needed but nice if provided)
+optional: Date
+
+Test results on Software-Version:   e.g. v.0.22.B (optional: Date)
+Test results on Board Revision:     e.g. Focci V3
+
+Findings:
+
+e.g.:
+- worked perfect
+- problems with xyz (exact description of the problem is appreciated)
+- failed at xyz (exact failure circumstances and description aswell as suspected failure source is appreciated)
+
+
+
+
+
+


### PR DESCRIPTION
Added Markdown File to document test results on real world chargers.
Added a proposal for a formatting.

Proposed Use:
Can be linked in the read me and on the wiki. 

Benefit:
One central location where even larger test results can be added easy and  in a sorted manner

Possible disadvantage:
Bit complicated for readers of the wiki. 
Gets convoluted easy once there are many people adding data. Will be a very large list once many people implemented CCS using clara+focci.

Proposed future use to counter the cons:
When clara+focci has matured and we are confident in its abilitys it makes sense to add a section "supported chargers" to the wiki that only lists the most recent SW/HW confirmation on a specific model. Also its possible to still link to this as the test documentation. 
Has the benefit of preventing convolution/cluttering of the wiki, giving first time readers a good overview and also the ability to have a chronological more detail documentation of the tests at a designated place.

As usual this is just a proposal. Always open to discussion either here or in the forum 👍 