### PR TITLE
Automatic version string generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,14 @@ LD		      = $(PREFIX)-gcc
 OBJCOPY		= $(PREFIX)-objcopy
 OBJDUMP		= $(PREFIX)-objdump
 MKDIR_P     = mkdir -p
+GIT_VERSION := $(shell git describe --abbrev=6 --dirty --always --tags)
 CFLAGS		= -Os -Iinclude/ -Ilibopeninv/include -Ilibopencm3/include -Iexi -Iccs \
              -fno-common -fno-builtin -DSTM32F1 \
+			-DVER=$(GIT_VERSION) \
 				 -mcpu=cortex-m3 -mthumb -std=gnu99 -ffunction-sections -fdata-sections
 CPPFLAGS    = -Og -ggdb -Wall -Wextra -Iinclude/ -Ilibopeninv/include -Ilibopencm3/include -Iexi -Iccs \
             -fno-common -std=c++11 -pedantic -DSTM32F1 -DUSART_BAUDRATE=921600 \
+			-DVER=$(GIT_VERSION) \
 				-ffunction-sections -fdata-sections -fno-builtin -fno-rtti -fno-exceptions -fno-unwind-tables -mcpu=cortex-m3 -mthumb
 LDSCRIPT	  = linker.ld
 LDFLAGS    = -Llibopencm3/lib -T$(LDSCRIPT) -march=armv7 -nostartfiles -Wl,--gc-sections,-Map,linker.map

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -38,9 +38,6 @@
  * IDs are 16 bit, so 65535 is the maximum
  */
 
- //Define a version string of your firmware here
-#define VER 0.35.B
-
 #include "myLogging.h"
 
 //Next param id (increase when adding new parameter!): 30


### PR DESCRIPTION
Generate the version string from the current git tag. For example:
  v0.22.B

If there are more commits after the last tag the number of commits and current git hash is appended:
  v0.22.B-67-g8083bfe

If the repo has uncommitted local changes the version ends "-dirty":
  v0.22.B-67-g8083bf-dirty

Tests:
 - Build firmware and verify with strings that the binary contains the output from the git describe command.
 - Add a temporary tag and verify the generated string is updated
 - Not tested on real hardware so unable to download the parameter database via CAN to verify correctness