### PR TITLE
Update .gitmodules to work for docker compiler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "libopeninv"]
-	path = libopeninv
-	url = git@github.com:jsphuebner/libopeninv.git
+        path = libopeninv
+        url = https://www.github.com/jsphuebner/libopeninv.git
 [submodule "libopencm3"]
-	path = libopencm3
-	url = git@github.com:jsphuebner/libopencm3.git
+        path = libopencm3
+        url = https://www.github.com/jsphuebner/libopencm3.git
+


### PR DESCRIPTION
Fixes issues I was having. Compiler now does this and finishes compiling:

`GIT SUBMODULE
Submodule 'libopencm3' (https://www.github.com/jsphuebner/libopencm3.git) registered for path 'libopencm3'
Submodule 'libopeninv' (https://www.github.com/jsphuebner/libopeninv.git) registered for path 'libopeninv'
Cloning into '/app/ccs32clara/libopencm3'...
warning: redirecting to https://github.com/jsphuebner/libopencm3.git/
Cloning into '/app/ccs32clara/libopeninv'...
warning: redirecting to https://github.com/jsphuebner/libopeninv.git/
Submodule path 'libopencm3': checked out '3413ef88067558cba8be90be6aa339a33788f88e'
Submodule path 'libopeninv': checked out '613097e26ae578b032c320970be47d3428232fbb'
  MAKE libopencm3
make[1]: Entering directory '/app/ccs32clara/libopencm3'`