### PR TITLE
Bugfix/locking

### DIFF
--- a/ccs/acOBC.cpp
+++ b/ccs/acOBC.cpp
@@ -308,19 +308,13 @@ static void triggerActions()
             //Unlock connector when coming here from any other state
             if (Param::GetInt(Param::LockState) == LOCK_CLOSED && Param::GetBool(Param::AllowUnlock))//only unlock if allowed and lock is locked
             {
-                if(Param::GetInt(Param::ActuatorTest) == 0)
-                {
-                    hardwareInterface_triggerConnectorUnlocking();
-                }
+                hardwareInterface_triggerConnectorUnlocking();
             }
             break;
         case OBC_LOCK:
             if (Param::GetInt(Param::LockState) == LOCK_OPEN)//only trigger is lock is open
             {
-                if(Param::GetInt(Param::ActuatorTest) == 0)
-                {
-                    hardwareInterface_triggerConnectorLocking();
-                }
+                hardwareInterface_triggerConnectorLocking();
             }
             break;
         case OBC_PAUSE:

--- a/include/param_prj.h
+++ b/include/param_prj.h
@@ -108,7 +108,7 @@
     VALUE_ENTRY(StopReason,         STOPREASONS,     2017 ) \
     VALUE_ENTRY(checkpoint,         "dig",           2015 ) \
     VALUE_ENTRY(CanWatchdog,        "dig",           2016 ) \
-    VALUE_ENTRY(CanAwake,           OFFON,          2032 ) \
+    VALUE_ENTRY(CanAwake,           OFFON,           2032 ) \
     VALUE_ENTRY(ButtonPushed,       OFFON,           2033 ) \
     VALUE_ENTRY(cpuload,            "%",             2094 )
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -269,6 +269,7 @@ extern "C" int main(void)
 
     //backward compatibility, version 4 was the first to support the "stream" command
     Param::SetInt(Param::version, 4);
+    Param::SetInt(Param::LockState, LOCK_OPEN); //Assume lock open
     Param::Change(Param::PARAM_LAST); //Call callback one for general parameter propagation
     //Now all our main() does is running the terminal
     //All other processing takes place in the scheduler or other interrupt service routines

--- a/stm32-ccs.cbp
+++ b/stm32-ccs.cbp
@@ -62,6 +62,8 @@
 		<Unit filename="ccs/temperatures.h" />
 		<Unit filename="ccs/udpChecksum.cpp" />
 		<Unit filename="ccs/udpChecksum.h" />
+		<Unit filename="ccs/wakecontrol.cpp" />
+		<Unit filename="ccs/wakecontrol.h" />
 		<Unit filename="exi/BitInputStream.c">
 			<Option compilerVar="CC" />
 		</Unit>


### PR DESCRIPTION
Fixed locking issues #46
- Do not drive lock with full PWM when operating without feedback
- Reset ActuatorTest to None when testing lock
- Do not open lock when test is done, must be done manually
- Assume lock to be open at powerup