### PR TITLE
Reset tcp connections before ending them

### DIFF
--- a/ccs/tcp.cpp
+++ b/ccs/tcp.cpp
@@ -335,7 +335,7 @@ void tcp_Disconnect(void)
 
 void tcp_reset(void)
 {
-   /* Tesla v2 (at least mine) seem to run tcp over a bus that never times out:-) It deliver packets to
+   /* Tesla v2 (at least mine) seem to run tcp over a queue that never times out:-) It deliver packets to
    previously used/wrong ports, several days since my last visit! A brutal RST seems to do the trick,
    no more wrong-port packets delivered after this.
    TODO: also call tcp_reset() before powerOff, to make sure the last connection is also freed.


### PR DESCRIPTION
This will prevent lots of wrong-port messages "[TCP] wrong port." at least on (my) Tesla v2 charger:-)
It will not prevent all of them as the last connection should also be reset before powerOff / unplugg, but it will prevent them for previously ghosted connections made during a session.

I am not sure if the wrong-port packages actually do harm or if they are just annoying. I guess if unlucky, a packet from the last charging session could have the same port as a port currently being used. Maybe unlikely.
But for me it was nice to get the wrong-port messages away from the log, one less thing to worry about. 