### PR TITLE
Charger 'Plugit HUBE S' wont work without maxes in CurrentDemandReq

### DIFF
--- a/ccs/pevStateMachine.cpp
+++ b/ccs/pevStateMachine.cpp
@@ -292,14 +292,6 @@ static void pev_sendPowerDeliveryReq(uint8_t isOn)
    encodeAndTransmit();
 }
 
-static inline void setPhysicalValue(dinPhysicalValueType* pv, int16_t value, dinunitSymbolType unit, int8_t multiplier)
-{
-   pv->Value = value;
-   pv->Unit_isUsed = 1;
-   pv->Unit = unit;
-   pv->Multiplier = multiplier;
-}
-
 static void pev_sendCurrentDemandReq(void)
 {
    uint16_t UTarget, EVMaximumVoltageLimit;
@@ -353,15 +345,20 @@ static void pev_sendCurrentDemandReq(void)
    dinDocEnc.V2G_Message.Body.CurrentDemandReq.RemainingTimeToBulkSoC.Unit_isUsed = 1;
    dinDocEnc.V2G_Message.Body.CurrentDemandReq.RemainingTimeToBulkSoC.Value = 600; /* seconds */
 
-   // Charger 'Plugit HUBE S' wont work without maxes
 #define req dinDocEnc.V2G_Message.Body.CurrentDemandReq
-   req.EVMaximumVoltageLimit_isUsed = 1;
-   setPhysicalValue(&req.EVMaximumVoltageLimit, Param::GetInt(Param::MaxVoltage), dinunitSymbolType_V, 0);
+   // Charger 'Plugit HUBE S' wont work without maxes
+   req.EVMaximumVoltageLimit_isUsed = 1u;
+   req.EVMaximumVoltageLimit.Multiplier = 0;
+   req.EVMaximumVoltageLimit.Unit = dinunitSymbolType_V;
+   req.EVMaximumVoltageLimit.Unit_isUsed = 1;
+   req.EVMaximumVoltageLimit.Value = Param::GetInt(Param::MaxVoltage);
 
-   req.EVMaximumCurrentLimit_isUsed = 1;
-   setPhysicalValue(&req.EVMaximumCurrentLimit, Param::GetInt(Param::MaxCurrent), dinunitSymbolType_A, 0);
+   req.EVMaximumCurrentLimit_isUsed = 1u;
+   req.EVMaximumCurrentLimit.Multiplier = 0;
+   req.EVMaximumCurrentLimit.Unit = dinunitSymbolType_A;
+   req.EVMaximumCurrentLimit.Unit_isUsed = 1;
+   req.EVMaximumCurrentLimit.Value = Param::GetInt(Param::MaxCurrent);
 #undef req
-
    encodeAndTransmit();
 }
 


### PR DESCRIPTION
Trial and error: https://github.com/osexpert/ccs32clara-chademo/issues/11

I see that it least 2 cars send max v and a, so I guess/assume all cars send v and a and this is why this charger incorrectly rely on them always being there.

Ionic.
pyPLC/results/2023-04-16_at_home_Ioniq_in_currentDemandLoop.pcapng

CurrentDemandReq:
"EVMaximumVoltageLimit_isUsed": "1",
"EVMaximumVoltageLimit.Multiplier": "-1",
"EVMaximumVoltageLimit.Value": "4128",
"EVMaximumVoltageLimit.Unit": "V",
"EVMaximumCurrentLimit_isUsed": "1",
"EVMaximumCurrentLimit.Multiplier": "-1",
"EVMaximumCurrentLimit.Value": "2000",
"EVMaximumCurrentLimit.Unit": "A",
"EVMaximumPowerLimit_isUsed": "1",
"EVMaximumPowerLimit.Multiplier": "1",
"EVMaximumPowerLimit.Value": "9800",
"EVMaximumPowerLimit.Unit": "W",

BMW i3:
https://openinverter.org/forum/viewtopic.php?p=28799#p28799

In the current loop:
CurrentDemandReq [EV to EVSE]
...
EVMaximumVoltageLimit: 415.1V
EVMaximumCurrentLimit: 125A