### PR TITLE
Use tcp fin instead of rst when disconnecting (issue 58)

### DIFF
--- a/ccs/pevStateMachine.cpp
+++ b/ccs/pevStateMachine.cpp
@@ -1047,7 +1047,7 @@ static void stateFunctionWaitForSessionStopResponse(void)
       if (dinDocDec.V2G_Message.Body.SessionStopRes_isUsed)
       {
          // req -508
-         // Todo: close the TCP connection here.
+         tcp_disconnect();
          publishStatus("Stopped normally", "");
          addToTrace(MOD_PEV, "Charging is finished");
          pev_enterState(PEV_STATE_End);

--- a/ccs/tcp.h
+++ b/ccs/tcp.h
@@ -20,7 +20,7 @@ extern "C" {
 extern void tcp_Mainfunction(void);
 extern void evaluateTcpPacket(void);
 extern uint32_t tcp_getTotalNumberOfRetries(void);
-extern void tcp_Disconnect(void);
+extern void tcp_disconnect(void);
 extern void tcp_transmit(void);
 
 #ifdef __cplusplus


### PR DESCRIPTION
If receive with flag fin, ack it and close connection. Call tcp_disconnect() in state machine.
Add tcp_disconnect: if established -> sendFin, if syn sent -> sendReset. Hopefully fixes issue 58 where charger do not like being sent a RST. Not tested here, allthou I run similar code in ccs32clara-chademo with success.