### PR TITLE
Drop unused DIN header signature fields to reduce EXI RAM

### DIFF
--- a/exi/dinEXIDatatypes.c
+++ b/exi/dinEXIDatatypes.c
@@ -635,7 +635,6 @@ void init_dinEVChargeParameterType(struct dinEVChargeParameterType* dinEVChargeP
 
 void init_dinMessageHeaderType(struct dinMessageHeaderType* dinMessageHeaderType) {
 	dinMessageHeaderType->Notification_isUsed = 0u;
-	dinMessageHeaderType->Signature_isUsed = 0u;
 }
 
 void init_dinBodyBaseType(struct dinBodyBaseType* dinBodyBaseType) {
@@ -966,4 +965,3 @@ void init_dinSubCertificatesType(struct dinSubCertificatesType* dinSubCertificat
 #endif /* DEPLOY_DIN_CODEC */
 
 #endif
-

--- a/exi/dinEXIDatatypes.h
+++ b/exi/dinEXIDatatypes.h
@@ -1814,7 +1814,7 @@ struct dinSalesTariffType {
 	} SalesTariffEntry;
 };
 
-/* Complex type name='urn:iso:15118:2:2010:MsgHeader,MessageHeaderType',  base type name='anyType',  content type='ELEMENT',  isAbstract='false',  hasTypeId='false',  final='0',  block='0',  particle='("urn:iso:15118:2:2010:MsgHeader":SessionID,"urn:iso:15118:2:2010:MsgHeader":Notification{0-1},"http://www.w3.org/2000/09/xmldsig#":Signature{0-1})',  derivedBy='RESTRICTION'.  */
+/* Complex type name='urn:iso:15118:2:2010:MsgHeader,MessageHeaderType',  base type name='anyType',  content type='ELEMENT',  isAbstract='false',  hasTypeId='false',  final='0',  block='0',  particle='("urn:iso:15118:2:2010:MsgHeader":SessionID,"urn:iso:15118:2:2010:MsgHeader":Notification{0-1})',  derivedBy='RESTRICTION'.  */
 #define dinMessageHeaderType_SessionID_BYTES_SIZE 8 /* XML schema facet length for urn:iso:15118:2:2010:MsgDataTypes,sessionIDType is 8 */
 struct dinMessageHeaderType {
 	/* element: "urn:iso:15118:2:2010:MsgHeader":SessionID, urn:iso:15118:2:2010:MsgDataTypes,sessionIDType */
@@ -1825,9 +1825,6 @@ struct dinMessageHeaderType {
 	/* element: "urn:iso:15118:2:2010:MsgHeader":Notification, Complex type name='urn:iso:15118:2:2010:MsgDataTypes,NotificationType',  base type name='anyType',  content type='ELEMENT',  isAbstract='false',  hasTypeId='false',  final='0',  block='0',  particle='("urn:iso:15118:2:2010:MsgDataTypes":FaultCode,"urn:iso:15118:2:2010:MsgDataTypes":FaultMsg{0-1})',  derivedBy='RESTRICTION'.  */
 	struct dinNotificationType Notification ;
 	unsigned int Notification_isUsed:1;
-	/* element: "http://www.w3.org/2000/09/xmldsig#":Signature, Complex type name='http://www.w3.org/2000/09/xmldsig#,SignatureType',  base type name='anyType',  content type='ELEMENT',  isAbstract='false',  hasTypeId='false',  final='0',  block='0',  particle='("http://www.w3.org/2000/09/xmldsig#":SignedInfo,"http://www.w3.org/2000/09/xmldsig#":SignatureValue,"http://www.w3.org/2000/09/xmldsig#":KeyInfo{0-1},"http://www.w3.org/2000/09/xmldsig#":Object{0-UNBOUNDED})',  derivedBy='RESTRICTION'.  */
-	struct dinSignatureType Signature ;
-	unsigned int Signature_isUsed:1;
 };
 
 /* Complex type name='urn:iso:15118:2:2010:MsgDataTypes,SAScheduleTupleType',  base type name='anyType',  content type='ELEMENT',  isAbstract='false',  hasTypeId='false',  final='0',  block='0',  particle='("urn:iso:15118:2:2010:MsgDataTypes":SAScheduleTupleID,"urn:iso:15118:2:2010:MsgDataTypes":PMaxSchedule,"urn:iso:15118:2:2010:MsgDataTypes":SalesTariff{0-1})',  derivedBy='RESTRICTION'.  */

--- a/exi/dinEXIDatatypesDecoder.c
+++ b/exi/dinEXIDatatypesDecoder.c
@@ -5123,7 +5123,7 @@ static int decode_dinEVChargeParameterType(bitstream_t* stream, struct dinEVChar
 	return errn;
 }
 
-/* Complex type name='urn:iso:15118:2:2010:MsgHeader,MessageHeaderType',  base type name='anyType',  content type='ELEMENT',  isAbstract='false',  hasTypeId='false',  final='0',  block='0',  particle='("urn:iso:15118:2:2010:MsgHeader":SessionID,"urn:iso:15118:2:2010:MsgHeader":Notification{0-1},"http://www.w3.org/2000/09/xmldsig#":Signature{0-1})',  derivedBy='RESTRICTION'.  */
+/* Complex type name='urn:iso:15118:2:2010:MsgHeader,MessageHeaderType',  base type name='anyType',  content type='ELEMENT',  isAbstract='false',  hasTypeId='false',  final='0',  block='0',  particle='("urn:iso:15118:2:2010:MsgHeader":SessionID,"urn:iso:15118:2:2010:MsgHeader":Notification{0-1})',  derivedBy='RESTRICTION'.  */
 static int decode_dinMessageHeaderType(bitstream_t* stream, struct dinMessageHeaderType* dinMessageHeaderType) {
 	int grammarID = 108;
 	int done = 0;
@@ -5171,7 +5171,7 @@ static int decode_dinMessageHeaderType(bitstream_t* stream, struct dinMessageHea
 			}
 			break;
 		case 109:
-			/* Element[START_ELEMENT({urn:iso:15118:2:2010:MsgHeader}Notification), START_ELEMENT({http://www.w3.org/2000/09/xmldsig#}Signature), END_ELEMENT] */
+			/* Element[START_ELEMENT({urn:iso:15118:2:2010:MsgHeader}Notification), END_ELEMENT] */
 			errn = decodeNBitUnsignedInteger(stream, 2, &eventCode);
 			if (errn == 0) {
 				switch(eventCode) {
@@ -5179,11 +5179,6 @@ static int decode_dinMessageHeaderType(bitstream_t* stream, struct dinMessageHea
 					errn = decode_dinNotificationType(stream, &dinMessageHeaderType->Notification);
 					dinMessageHeaderType->Notification_isUsed = 1u;
 					grammarID = 110;
-					break;
-				case 1:
-					errn = decode_dinSignatureType(stream, &dinMessageHeaderType->Signature);
-					dinMessageHeaderType->Signature_isUsed = 1u;
-					grammarID = 4;
 					break;
 				case 2:
 					done = 1;
@@ -5196,15 +5191,10 @@ static int decode_dinMessageHeaderType(bitstream_t* stream, struct dinMessageHea
 			}
 			break;
 		case 110:
-			/* Element[START_ELEMENT({http://www.w3.org/2000/09/xmldsig#}Signature), END_ELEMENT] */
+			/* Element[END_ELEMENT] */
 			errn = decodeNBitUnsignedInteger(stream, 2, &eventCode);
 			if (errn == 0) {
 				switch(eventCode) {
-				case 0:
-					errn = decode_dinSignatureType(stream, &dinMessageHeaderType->Signature);
-					dinMessageHeaderType->Signature_isUsed = 1u;
-					grammarID = 4;
-					break;
 				case 1:
 					done = 1;
 					grammarID = 5;

--- a/exi/dinEXIDatatypesEncoder.c
+++ b/exi/dinEXIDatatypesEncoder.c
@@ -3664,7 +3664,7 @@ static int encode_dinEVChargeParameterType(bitstream_t* stream, struct dinEVChar
 	return errn;
 }
 
-/* Complex type name='urn:iso:15118:2:2010:MsgHeader,MessageHeaderType',  base type name='anyType',  content type='ELEMENT',  isAbstract='false',  hasTypeId='false',  final='0',  block='0',  particle='("urn:iso:15118:2:2010:MsgHeader":SessionID,"urn:iso:15118:2:2010:MsgHeader":Notification{0-1},"http://www.w3.org/2000/09/xmldsig#":Signature{0-1})',  derivedBy='RESTRICTION'.  */
+/* Complex type name='urn:iso:15118:2:2010:MsgHeader,MessageHeaderType',  base type name='anyType',  content type='ELEMENT',  isAbstract='false',  hasTypeId='false',  final='0',  block='0',  particle='("urn:iso:15118:2:2010:MsgHeader":SessionID,"urn:iso:15118:2:2010:MsgHeader":Notification{0-1})',  derivedBy='RESTRICTION'.  */
 static int encode_dinMessageHeaderType(bitstream_t* stream, struct dinMessageHeaderType* dinMessageHeaderType) {
 	int grammarID = 108;
 	int done = 0;
@@ -3694,19 +3694,13 @@ static int encode_dinMessageHeaderType(bitstream_t* stream, struct dinMessageHea
 			}
 			break;
 		case 109:
-			/* Element[START_ELEMENT({urn:iso:15118:2:2010:MsgHeader}Notification), START_ELEMENT({http://www.w3.org/2000/09/xmldsig#}Signature), END_ELEMENT] */
+			/* Element[START_ELEMENT({urn:iso:15118:2:2010:MsgHeader}Notification), END_ELEMENT] */
 			if ( dinMessageHeaderType->Notification_isUsed == 1u ) {
 				errn = encodeNBitUnsignedInteger(stream, 2, 0);
 				if(errn == 0) {
 					errn = encode_dinNotificationType(stream, &dinMessageHeaderType->Notification );
 				}
 				grammarID = 110;
-			} else 			if ( dinMessageHeaderType->Signature_isUsed == 1u ) {
-				errn = encodeNBitUnsignedInteger(stream, 2, 1);
-				if(errn == 0) {
-					errn = encode_dinSignatureType(stream, &dinMessageHeaderType->Signature );
-				}
-				grammarID = 4;
 			} else 			if (1==1) {
 				errn = encodeNBitUnsignedInteger(stream, 2, 2);
 				if(errn == 0) {
@@ -3718,14 +3712,8 @@ static int encode_dinMessageHeaderType(bitstream_t* stream, struct dinMessageHea
 			}
 			break;
 		case 110:
-			/* Element[START_ELEMENT({http://www.w3.org/2000/09/xmldsig#}Signature), END_ELEMENT] */
-			if ( dinMessageHeaderType->Signature_isUsed == 1u ) {
-				errn = encodeNBitUnsignedInteger(stream, 2, 0);
-				if(errn == 0) {
-					errn = encode_dinSignatureType(stream, &dinMessageHeaderType->Signature );
-				}
-				grammarID = 4;
-			} else 			if (1==1) {
+			/* Element[END_ELEMENT] */
+			if (1==1) {
 				errn = encodeNBitUnsignedInteger(stream, 2, 1);
 				if(errn == 0) {
 					done = 1;


### PR DESCRIPTION
The EXI codec allocated significant RAM for DIN message-header signature data that the application never reads, writes, or relies on. This change removes that dead state from the DIN header path to reduce persistent EXI document memory usage.

- **DIN header datatype slimming**
  - Removed `Signature` and `Signature_isUsed` from `dinMessageHeaderType` in `exi/dinEXIDatatypes.h`.
  - Kept `SessionID` and optional `Notification` handling intact.

- **Initializer alignment**
  - Updated `init_dinMessageHeaderType()` in `exi/dinEXIDatatypes.c` to stop initializing the removed signature flag.

- **Header grammar path cleanup (encoder/decoder)**
  - Simplified `encode_dinMessageHeaderType()` (`exi/dinEXIDatatypesEncoder.c`) by removing signature branches from grammar states.
  - Simplified `decode_dinMessageHeaderType()` (`exi/dinEXIDatatypesDecoder.c`) with matching branch removal, preserving SessionID + Notification flow.

- **Resulting memory effect**
  - The dominant EXI document container shrinks substantially because `dinMessageHeaderType` no longer embeds the large XMLDSIG structure.

```c
/* before */
struct dinMessageHeaderType {
    SessionID;
    struct dinNotificationType Notification;
    unsigned int Notification_isUsed:1;
    struct dinSignatureType Signature;
    unsigned int Signature_isUsed:1;
};

/* after */
struct dinMessageHeaderType {
    SessionID;
    struct dinNotificationType Notification;
    unsigned int Notification_isUsed:1;
};
```